### PR TITLE
Implement metric track of page views

### DIFF
--- a/config/mongoCollections.js
+++ b/config/mongoCollections.js
@@ -24,4 +24,5 @@ module.exports = {
     products: getCollectionFn("products"),
     reviews: getCollectionFn("reviews"),
     orders: getCollectionFn("orders"),
+    metrics: getCollectionFn("metrics"),
 };

--- a/data/index.js
+++ b/data/index.js
@@ -2,10 +2,12 @@ const usersData = require('./users');
 const productsData = require('./products');
 const reviewsData = require('./reviews');
 const ordersData = require('./orders');
+const metricsData = require('./metrics');
 
 module.exports = {
   users: usersData,
   products: productsData,
   reviews: reviewsData,
   orders: ordersData,
+  metrics: metricsData
 };

--- a/data/metrics.js
+++ b/data/metrics.js
@@ -1,0 +1,30 @@
+const { ObjectId } = require('mongodb');
+const metrics = require('../config/mongoCollections').metrics;
+const mongoOperations = require('./mongoOperations');
+
+
+const getAll = async () => {
+    const metricCollection = await metrics();
+    const allMetrics = await metricCollection.find({}).toArray();
+
+    return mongoOperations.resultsToSet(allMetrics, "productId", "pageView");
+}
+
+const notifyProductPageView = async (id) => {
+    const metricCollection = await metrics();
+
+    const query = { productId: ObjectId(id) };
+    const result = await metricCollection.updateOne(query, {$inc: { pageView: 1}}, {upsert: true});
+    // Log instead of throw, as metrics are a side effect to the request
+    if(!result || (result.modifiedCount == 0 && result.upsertedCount == 0) ) {
+        console.error(`Failed to record page view for ${id}`);
+    }
+}
+
+
+
+module.exports = {
+    getAll,
+    notifyProductPageView
+  };
+  

--- a/data/metrics.js
+++ b/data/metrics.js
@@ -1,4 +1,5 @@
 const { ObjectId } = require('mongodb');
+const metricSchema = require('../schemas/new_metric');
 const metrics = require('../config/mongoCollections').metrics;
 const mongoOperations = require('./mongoOperations');
 
@@ -10,21 +11,38 @@ const getAll = async () => {
     return mongoOperations.resultsToSet(allMetrics, "productId", "pageView");
 }
 
-const notifyProductPageView = async (id) => {
+/// Internal function, all functions exposed in module.exports should validate before calling this function.
+upsertPageView = async (id) => {
+    
     const metricCollection = await metrics();
-
-    const query = { productId: ObjectId(id) };
+    const query = { productId:  id};
     const result = await metricCollection.updateOne(query, {$inc: { pageView: 1}}, {upsert: true});
-    // Log instead of throw, as metrics are a side effect to the request
+    
     if(!result || (result.modifiedCount == 0 && result.upsertedCount == 0) ) {
         console.error(`Failed to record page view for ${id}`);
     }
+}
+
+const notifyProductPageView = async (rawId) => {
+    const { error } =  metricSchema.validate({id: rawId}, {abortEarly: false, allowUnknown: true, stripUnknown: true});
+    // Log instead of throw for this error. Metrics are a side effect to the request and should not prevent the main request from going through.
+    if (error) {
+        console.error(`Failed to valid ${rawId} due to ${error}, ignoring metric`);
+        return;
+    }
+    await upsertPageView(ObjectId(rawId));
+}
+   
+
+const notifyLandingPageView = async () => {
+    await upsertPageView("landingPage");
 }
 
 
 
 module.exports = {
     getAll,
+    notifyLandingPageView,
     notifyProductPageView
   };
   

--- a/data/mongoOperations.js
+++ b/data/mongoOperations.js
@@ -1,0 +1,6 @@
+module.exports = {
+    // reduce the array in form `[{key0: value0}, {key1: value1}]` to an object of form `{key0: count0, key1: count1} to expose a dictionary with constant time look-up
+    resultsToSet: (array, objectKey, propertyKey) => {
+        return array.reduce( (acc, curr) => ({ ...acc, [curr[objectKey].toString()]:  curr[propertyKey]}), {})
+    }
+}

--- a/data/orders.js
+++ b/data/orders.js
@@ -4,6 +4,7 @@ const orders = mongoCollections.orders;
 const users = require('./users');
 const products = require('./products');
 const new_order_schema = require('../schemas/new_order');
+const mongoOperations = require('./mongoOperations');
 
 async function get(id) {
   if (typeof id !== 'string') throw `id must be a string but ${typeof id} provided`;
@@ -106,8 +107,7 @@ async function aggregateOrders() {
               ])
               .toArray()
   // As toArray does not allow pretty chaining, allow for the await to finish and collect the value before reducing. 
-  // Then reduce the array in form `[{key1: count1}, {key1: count1}]` to an object of form `{key1: count1, key2: count2} to expose a dictionary with constant time look-up
-  return data.reduce( (acc, curr) => ({ ...acc, [curr._id.toString()]:  curr.count}), {})
+  return mongoOperations.resultsToSet(data, "_id", "count");
 }
 
 module.exports = {

--- a/data/products.js
+++ b/data/products.js
@@ -1,6 +1,7 @@
 const { ObjectId } = require('mongodb');
 const mongoCollections = require('../config/mongoCollections');
 const products = mongoCollections.products;
+const metrics = require('./metrics');
 
 async function get(id) {
   const productsCollection = await products();
@@ -8,6 +9,7 @@ async function get(id) {
 
   if (product !== null) {
     product._id = product._id.toString();
+    metrics.notifyProductPageView(product._id);
   }
 
   return product;
@@ -19,6 +21,7 @@ async function getBySlug(slug) {
 
   if (product !== null) {
     product._id = product._id.toString();
+    metrics.notifyProductPageView(product._id);
   }
 
   return product;

--- a/public/css/site.css
+++ b/public/css/site.css
@@ -43,18 +43,28 @@ div.pageContent {
     margin-left: 2em;
 }
 
-.productCard {
+.card, .productCard {
     border-width: 2px;
     border-style: solid;
     border-color: #CCC;
     background-color: #CCC;
-    filter: drop-shadow(.5rem 1.5rem 1rem gray);
     margin-bottom: 2em;
     border-radius: 10px;
     display: inline-block;
-    position: relative;
     padding: .2em;
     transition: top ease-in-out 0.5s;
+}
+
+.productCard {
+    position: relative;
+    filter: drop-shadow(.5rem 1.5rem 1rem gray);
+}
+
+.card:not(.productCard ) {
+    display: flex;
+    margin: auto;
+    max-width: 80%;
+    min-width: 55%;
 }
 .products {
     display: flex;
@@ -160,6 +170,9 @@ header {
     margin-left: 10px;
 }
 
+ul.noBullets {
+    list-style-type: none;
+}
 /*
 --------------------------------
 Product Page Styles

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -19,7 +19,7 @@ router.get("/", async (req, res) => {
     const productList = await products.getAllUpTo(20);
     const orderList = await orders.aggregateOrders();
     const pageViews = await metrics.getAll();
-    
+    let totalViews = 0
     productList.forEach(product => {
         const orderAmount = orderList[product._id];
         product.orderCount = !!orderAmount ? orderAmount : 0;
@@ -27,7 +27,13 @@ router.get("/", async (req, res) => {
         product.revenue = isNaN(revenue) ? 0 : revenue.toFixed(2);
         product.price = product.price.toFixed(2);
         product.pageViews = pageViews[product._id] ? pageViews[product._id] :0;
+        totalViews += product.pageViews;
       });
+
+      const totalProductViews = totalViews;
+      const landingPageViews = pageViews.landingPage ? pageViews.landingPage : 0; 
+
+      totalViews += landingPageViews;
 
       // Grab the top sellers, by revenue, and sort in descending order for handlebars
       const topSellers = productList
@@ -47,7 +53,11 @@ router.get("/", async (req, res) => {
               linkHome: true
           },
           user: user, 
-          metrics: {}, 
+          metrics: {
+            totalSiteViews: totalViews,
+            landingPageViews: landingPageViews, 
+            totalProductViews: totalProductViews
+          }, 
           products: productList,
           topSellers: topSellers
     }

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -1,7 +1,9 @@
 const express = require('express');
 const router = express.Router();
-const products = require("../data").products;
-const orders = require("../data").orders;
+const dataModel = require('../data');
+const products = dataModel.products;
+const orders = dataModel.orders;
+const metrics = dataModel.metrics;
 const authHelper = require("../middleware/authentication");
 const handlebarHelper = require("../middleware/handlebarsData");
 
@@ -16,14 +18,15 @@ router.get("/", async (req, res) => {
 
     const productList = await products.getAllUpTo(20);
     const orderList = await orders.aggregateOrders();
-
-
+    const pageViews = await metrics.getAll();
+    
     productList.forEach(product => {
         const orderAmount = orderList[product._id];
         product.orderCount = !!orderAmount ? orderAmount : 0;
         const revenue = orderAmount * product.price;
         product.revenue = isNaN(revenue) ? 0 : revenue.toFixed(2);
         product.price = product.price.toFixed(2);
+        product.pageViews = pageViews[product._id] ? pageViews[product._id] :0;
       });
 
       // Grab the top sellers, by revenue, and sort in descending order for handlebars

--- a/routes/index.js
+++ b/routes/index.js
@@ -2,8 +2,11 @@
 const userRoutes = require("./user");
 const productRoutes = require("./products");
 const adminRoutes = require("./admin");
-const products = require("../data").products;
+const data = require("../data");
+const products = data.products;
+const metrics = data.metrics;
 const ordersRoutes = require("./orders")
+
 
 const constructorMethod = (app) => {
   app.use('/user', userRoutes);
@@ -13,6 +16,7 @@ const constructorMethod = (app) => {
   app.use('/admin', adminRoutes);
 
   app.get('/', async (req, res ) => {
+    metrics.notifyLandingPageView();
 
     const productList = await products.getAllUpTo(20);
 

--- a/schemas/new_metric.js
+++ b/schemas/new_metric.js
@@ -1,0 +1,7 @@
+const Joi = require('joi');
+
+const schema = Joi.object({
+    id: Joi.string()
+  });
+
+module.exports = schema;

--- a/tasks/seed.js
+++ b/tasks/seed.js
@@ -201,6 +201,12 @@ async function seedDB() {
 
         console.log("Page views seeded");
 
+        for (let i = 0; i < 20; i++) {
+            await data.metrics.notifyLandingPageView();
+        }
+
+        console.log("Landing page metrics seeded")
+
         console.log("Seeding DB completed!");
         const db = await mongoConnection();
         await db.serverConfig.close();

--- a/views/layouts/admin.handlebars
+++ b/views/layouts/admin.handlebars
@@ -38,4 +38,12 @@
 {{/each}}
 </div>
 {{/if}}
+<div class="card">
+    <ul class="noBullets">
+        <li>Aggregate Site Views: {{metrics.totalSiteViews}}</li>
+        <li>Landing Page Views: {{metrics.landingPageViews}}</li>
+        <li>Summation of Product Views: {{metrics.totalProductViews}}</li>
+    </ul>
+</div>
+
 <script src="/js/adminPageLogic.js"></script>

--- a/views/layouts/admin.handlebars
+++ b/views/layouts/admin.handlebars
@@ -31,6 +31,7 @@
                 <button class="productRemoveButton">Remove for Sale</button>
             </span>
         </div>
+        <span> Times Viewed: {{pageViews}}</span>
 
 </a>
 


### PR DESCRIPTION
Changes
---
- Created metric collection to store page view data
- Business logic added to track when products are viewed
- Refactored common mongo mapping logic to its own file
- Page views are showed at the bottom of the card on the Admin panel
- Put seed data for the page views to be consistent, and not as a side effect of other populations 