### PR TITLE
Fix contrast issues identifed by tota11y

### DIFF
--- a/public/css/site.css
+++ b/public/css/site.css
@@ -28,7 +28,7 @@ div.pageContent {
 }
 
 .lowStock {
-    color: lightcoral;
+    color: #b20000;
 }
 
 .stock {
@@ -53,6 +53,7 @@ div.pageContent {
     display: inline-block;
     padding: .2em;
     transition: top ease-in-out 0.5s;
+    color: black;
 }
 
 .productCard {
@@ -92,9 +93,10 @@ div.pageContent {
     display: inline-block;
 }
 
-.productCard:hover {
+.productCard:hover, .card:hover{
     background-color: #BBB;
     top: -0.5em;
+    color: #00409d;
 }
 
 .scrollTarget.productCard:hover{
@@ -222,6 +224,9 @@ Product Page Styles
     justify-content: left;
     transform: translateY(100%);
     margin: 0 !important;
+}
+.carousel-control-prev, .carousel-control-next {
+    color: black;
 }
 
 .carousel-indicators button:first-child {

--- a/routes/products.js
+++ b/routes/products.js
@@ -14,7 +14,7 @@ router.get("/:slug", async (req, res) => {
     metrics.notifyProductPageView(product._id);
 
     const reviews = await reviewData.getByProductId(product._id);
-    res.render("pages/product", {...product, user: req.session.user, reviews, partial: 'review-scripts'});
+    res.render("pages/product", {...product, user: req.session.user, reviews, partial: 'review-scripts', footer: {linkHome: true} });
 
 });
 

--- a/views/pages/product.handlebars
+++ b/views/pages/product.handlebars
@@ -5,7 +5,7 @@
                 <div class="carousel-inner">
                     {{#each pictures}}
                         <div class="carousel-item carousel-image {{#unless @index}}active{{/unless}}">
-                            <img src="{{this}}" class="d-block w-100" alt="TODO">
+                            <img src="{{this}}" class="d-block w-100" alt="{{../name}} in action.">
                         </div>
                     {{/each}}
                 </div>
@@ -24,7 +24,7 @@
                         <button type="button" data-bs-target="#productImages"
                                 {{#unless @index}}class="active"{{/unless}} data-bs-slide-to="{{@index}}"
                                 aria-label="Slide {{@index}}">
-                            <img src="{{this}}" class="d-block w-100" alt="TODO">
+                            <img src="{{this}}" class="d-block w-100" alt="{{../name}} in action.">
                         </button>
                     {{/each}}
                 </div>


### PR DESCRIPTION
Changes
---
- Links on cards are now black text when not hovered. Hovering uses a darker blue
- Low stock is a darker red
- Hidden Carousel selector changed to black to resolve warning
- Updated alt text on product images
- Product pages now have a link to the home page


Note: There is one remaining contrast issue identified by tota11y on the drop-down on the product page. This appears to be rooted in bootstrap and therefore acceptable to leave. Applying the suggestion from tota11y still has the error persist. 